### PR TITLE
Add vertical digit ticker animation

### DIFF
--- a/src/components/AnimatedNumber.tsx
+++ b/src/components/AnimatedNumber.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { formatCurrency } from "../utils";
+
+interface AnimatedNumberProps {
+  value: number;
+  className?: string;
+}
+
+const Digit: React.FC<{ char: string }> = ({ char }) => {
+  const isDigit = /\d/.test(char);
+
+  if (!isDigit) {
+    return (
+      <span className="inline-block w-[0.6em]">{char}</span>
+    );
+  }
+
+  return (
+    <span className="relative inline-block overflow-hidden w-[0.6em] h-[1em]">
+      <AnimatePresence initial={false}>
+        <motion.span
+          key={char}
+          initial={{ y: "100%" }}
+          animate={{ y: 0 }}
+          exit={{ y: "-100%" }}
+          transition={{ duration: 0.3, ease: "easeInOut" }}
+          className="absolute inset-0"
+        >
+          {char}
+        </motion.span>
+      </AnimatePresence>
+    </span>
+  );
+};
+
+const AnimatedNumber: React.FC<AnimatedNumberProps> = ({ value, className = "" }) => {
+  const formatted = formatCurrency(value);
+
+  return (
+    <div className={`flex ${className}`.trim()}>
+      {formatted.split("").map((char, idx) => (
+        <Digit key={`${char}-${idx}`} char={char} />
+      ))}
+    </div>
+  );
+};
+
+export default AnimatedNumber;

--- a/src/components/EarningsCounter.tsx
+++ b/src/components/EarningsCounter.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import AnimatedNumber from "./AnimatedNumber";
 import { Settings } from "../types";
 import {
   formatCurrency,
@@ -44,9 +45,10 @@ const EarningsCounter: React.FC<EarningsCounterProps> = ({ settings }) => {
     <div className="flex flex-col items-center justify-center space-y-6">
       {/* Main earnings counter */}
       <div className="text-center">
-        <div className="text-5xl md:text-7xl font-bold text-gray-900 dark:text-white font-mono">
-          {formatCurrency(currentEarnings)}
-        </div>
+        <AnimatedNumber
+          value={currentEarnings}
+          className="text-5xl md:text-7xl font-bold text-gray-900 dark:text-white font-mono"
+        />
       </div>
 
       {/* Progress bar */}


### PR DESCRIPTION
## Summary
- animate each digit change in earnings counter with Framer Motion ticker effect

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d2d33894833181f9f04193a871bb